### PR TITLE
Add updateIncomingCall()

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,20 @@ Initialise RNCallKit with options
 
 Call when you receive incoming calls to display system UI
 
+### updateIncomingCall
+
+- **uuid**: string
+- **handle**: string
+- **handleType**: string (optional)
+  - generic
+  - number (default)
+  - email
+- **hasVideo**: boolean (optional)
+  - false (default)
+- **localizedCallerName**: string (optional)
+
+Call when you have updated information about incoming calls to display
+
 ### startCall
 
 - **uuid**: string

--- a/index.js
+++ b/index.js
@@ -45,6 +45,11 @@ export default class RNCallKit {
         _RNCallKit.displayIncomingCall(uuid, handle, handleType, hasVideo, localizedCallerName);
     }
 
+    static updateIncomingCall(uuid, handle, handleType = 'number', hasVideo = false, localizedCallerName?: String) {
+        if (Platform.OS !== 'ios') return;
+        _RNCallKit.updateIncomingCall(uuid, handle, handleType, hasVideo, localizedCallerName);
+    }
+
     static startCall(uuid, handle, handleType = 'number', hasVideo = false, contactIdentifier?: String) {
         if (Platform.OS !== 'ios') return;
         _RNCallKit.startCall(uuid, handle, handleType, hasVideo, contactIdentifier);

--- a/ios/RNCallKit/RNCallKit.m
+++ b/ios/RNCallKit/RNCallKit.m
@@ -139,6 +139,30 @@ RCT_EXPORT_METHOD(displayIncomingCall:(NSString *)uuidString
     }];
 }
 
+// Update display information about the incoming call
+RCT_EXPORT_METHOD(updateIncomingCall:(NSString *)uuidString
+                               handle:(NSString *)handle
+                           handleType:(NSString *)handleType
+                             hasVideo:(BOOL)hasVideo
+                  localizedCallerName:(NSString * _Nullable)localizedCallerName)
+{
+#ifdef DEBUG
+    NSLog(@"[RNCallKit][updateIncomingCall] uuidString = %@", uuidString);
+#endif
+    int _handleType = [self getHandleType:handleType];
+    NSUUID *uuid = [[NSUUID alloc] initWithUUIDString:uuidString];
+    CXCallUpdate *callUpdate = [[CXCallUpdate alloc] init];
+    callUpdate.remoteHandle = [[CXHandle alloc] initWithType:_handleType value:handle];
+    callUpdate.supportsDTMF = YES;
+    // TODO: Holding
+    callUpdate.supportsHolding = NO;
+    callUpdate.supportsGrouping = NO;
+    callUpdate.supportsUngrouping = NO;
+    callUpdate.hasVideo = hasVideo;
+    callUpdate.localizedCallerName = localizedCallerName;
+    [self.callKitProvider reportCallWithUUID:uuid updated:callUpdate];
+}
+
 RCT_EXPORT_METHOD(startCall:(NSString *)uuidString
                      handle:(NSString *)handle
                  handleType:(NSString *)handleType


### PR DESCRIPTION
Allow updating information on the call screen when it becomes available.

`updateIncomingCall()` takes the same arguments as `displayIncomingCall()` but updates an existing call instead.