### PR TITLE
Support DTMF and change muted payload

### DIFF
--- a/actions.js
+++ b/actions.js
@@ -12,6 +12,7 @@ const RNCallKitPerformEndCallAction = 'RNCallKitPerformEndCallAction';
 const RNCallKitDidActivateAudioSession = 'RNCallKitDidActivateAudioSession';
 const RNCallKitDidDisplayIncomingCall = 'RNCallKitDidDisplayIncomingCall';
 const RNCallKitDidPerformSetMutedCallAction = 'RNCallKitDidPerformSetMutedCallAction';
+const RNCallKitPerformPlayDTMFCallAction = 'RNCallKitPerformPlayDTMFCallAction';
 
 didReceiveStartCallAction = handler => {
     const listener = _RNCallKitEmitter.addListener(
@@ -53,7 +54,14 @@ didDisplayIncomingCall = handler => (
 didPerformSetMutedCallAction = handler => (
     _RNCallKitEmitter.addListener(
         RNCallKitDidPerformSetMutedCallAction,
-        (data) => { handler(data.muted); }
+        (data) => { handler(data); }
+    )
+)
+
+playDTMF = handler => (
+    _RNCallKitEmitter.addListener(
+        RNCallKitPerformPlayDTMFCallAction,
+        (data) => { handler(data); }
     )
 )
 
@@ -61,6 +69,7 @@ export const listeners = {
     didReceiveStartCallAction,
     answerCall,
     endCall,
+    playDTMF,
     didActivateAudioSession,
     didDisplayIncomingCall,
     didPerformSetMutedCallAction,

--- a/ios/RNCallKit/RNCallKit.m
+++ b/ios/RNCallKit/RNCallKit.m
@@ -24,6 +24,7 @@ static NSString *const RNCallKitPerformEndCallAction = @"RNCallKitPerformEndCall
 static NSString *const RNCallKitDidActivateAudioSession = @"RNCallKitDidActivateAudioSession";
 static NSString *const RNCallKitDidDisplayIncomingCall = @"RNCallKitDidDisplayIncomingCall";
 static NSString *const RNCallKitDidPerformSetMutedCallAction = @"RNCallKitDidPerformSetMutedCallAction";
+static NSString *const RNCallKitPerformPlayDTMFCallAction = @"RNCallKitPerformPlayDTMFCallAction";
 
 @implementation RNCallKit
 {
@@ -73,7 +74,8 @@ RCT_EXPORT_MODULE()
              RNCallKitPerformEndCallAction,
              RNCallKitDidActivateAudioSession,
              RNCallKitDidDisplayIncomingCall,
-             RNCallKitDidPerformSetMutedCallAction
+             RNCallKitDidPerformSetMutedCallAction,
+             RNCallKitPerformPlayDTMFCallAction
              ];
 }
 
@@ -503,6 +505,14 @@ continueUserActivity:(NSUserActivity *)userActivity
 #ifdef DEBUG
     NSLog(@"[RNCallKit][CXProviderDelegate][provider:performSetHeldCallAction]");
 #endif
+}
+
+- (void)provider:(CXProvider *)provider performPlayDTMFCallAction:(CXPlayDTMFCallAction *)action {
+#ifdef DEBUG
+    NSLog(@"[RNCallKit][CXProviderDelegate][provider:performPlayDTMFCallAction]");
+#endif
+    [self sendEventWithName:RNCallKitPerformPlayDTMFCallAction body:@{ @"digits": action.digits }];
+    [action fulfill];
 }
 
 - (void)provider:(CXProvider *)provider timedOutPerformingAction:(CXAction *)action

--- a/ios/RNCallKit/RNCallKit.m
+++ b/ios/RNCallKit/RNCallKit.m
@@ -511,7 +511,8 @@ continueUserActivity:(NSUserActivity *)userActivity
 #ifdef DEBUG
     NSLog(@"[RNCallKit][CXProviderDelegate][provider:performPlayDTMFCallAction]");
 #endif
-    [self sendEventWithName:RNCallKitPerformPlayDTMFCallAction body:@{ @"digits": action.digits }];
+    NSString *callUUID = [self containsLowerCaseLetter:action.callUUID.UUIDString] ? action.callUUID.UUIDString : [action.callUUID.UUIDString lowercaseString];
+    [self sendEventWithName:RNCallKitPerformPlayDTMFCallAction body:@{ @"digits": action.digits, @"callUUID": callUUID }];
     [action fulfill];
 }
 
@@ -542,7 +543,8 @@ continueUserActivity:(NSUserActivity *)userActivity
 #ifdef DEBUG
     NSLog(@"[RNCallKit][CXProviderDelegate][provider:performSetMutedCallAction]");
 #endif
-    [self sendEventWithName:RNCallKitDidPerformSetMutedCallAction body:@{ @"muted": @(action.muted) }];
+    NSString *callUUID = [self containsLowerCaseLetter:action.callUUID.UUIDString] ? action.callUUID.UUIDString : [action.callUUID.UUIDString lowercaseString];
+    [self sendEventWithName:RNCallKitDidPerformSetMutedCallAction body:@{ @"muted": @(action.muted), @"callUUID": callUUID }];
     [action fulfill];
 }
 


### PR DESCRIPTION
Forward DTMF digits from native call UI when call is answered from lock screen.

Also, change the payload for the muted action, so the payload is an object rather than just a boolean (for consistency with other event handlers).