### PR TITLE
Add reportEndedCallWithUUID

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,6 +12,11 @@ const _RNCallKit = NativeModules.RNCallKit;
 const _callkitEventHandlers = new Map();
 
 export default class RNCallKit {
+    static CXCallEndedReasonFailed = _RNCallKit.CXCallEndedReasonFailed
+    static CXCallEndedReasonRemoteEnded = _RNCallKit.CXCallEndedReasonRemoteEnded
+    static CXCallEndedReasonUnanswered = _RNCallKit.CXCallEndedReasonUnanswered
+    static CXCallEndedReasonAnsweredElsewhere = _RNCallKit.CXCallEndedReasonAnsweredElsewhere
+    static CXCallEndedReasonDeclinedElsewhere = _RNCallKit.CXCallEndedReasonDeclinedElsewhere
 
     static addEventListener(type, handler) {
         if (Platform.OS !== 'ios') return;
@@ -53,6 +58,11 @@ export default class RNCallKit {
     static reportConnectedOutgoingCallWithUUID(uuid) {
         if (Platform.OS !== 'ios') return;
         _RNCallKit.reportConnectedOutgoingCallWithUUID(uuid);
+    }
+
+    static reportEndedCallWithUUID(uuid, reason) {
+        if (Platform.OS !== 'ios') return;
+        _RNCallKit.reportEndedCallWithUUID(uuid, reason);
     }
 
     static endCall(uuid) {

--- a/ios/RNCallKit/RNCallKit.m
+++ b/ios/RNCallKit/RNCallKit.m
@@ -271,7 +271,7 @@ RCT_EXPORT_METHOD(reportConnectedOutgoingCallWithUUID:(NSString *)uuidString)
 RCT_EXPORT_METHOD(reportEndedCallWithUUID:(NSString *)uuidString reason:(CXCallEndedReason)reason)
 {
     NSUUID *uuid = [[NSUUID alloc] initWithUUIDString:uuidString];
-    [self.callKitProvider reportCallWithUUID:uuid endedAtDate:[NSDate date] reason:CXCallEndedReasonFailed];
+    [self.callKitProvider reportCallWithUUID:uuid endedAtDate:[NSDate date] reason:reason];
 }
 
 RCT_EXPORT_METHOD(setMutedCall:(NSString *)uuidString muted:(BOOL)muted resolver:(RCTPromiseResolveBlock) resolve rejecter: (RCTPromiseRejectBlock) reject)

--- a/ios/RNCallKit/RNCallKit.m
+++ b/ios/RNCallKit/RNCallKit.m
@@ -26,6 +26,16 @@ static NSString *const RNCallKitDidDeactivateAudioSession = @"RNCallKitDidDeacti
 static NSString *const RNCallKitDidDisplayIncomingCall = @"RNCallKitDidDisplayIncomingCall";
 static NSString *const RNCallKitDidPerformSetMutedCallAction = @"RNCallKitDidPerformSetMutedCallAction";
 
+@implementation RCTConvert (CallEndedReason)
+  RCT_ENUM_CONVERTER(CXCallEndedReason, (@{
+    @"CXCallEndedReasonFailed": @(CXCallEndedReasonFailed),
+    @"CXCallEndedReasonRemoteEnded": @(CXCallEndedReasonRemoteEnded),
+    @"CXCallEndedReasonUnanswered": @(CXCallEndedReasonUnanswered),
+    @"CXCallEndedReasonAnsweredElsewhere": @(CXCallEndedReasonAnsweredElsewhere),
+    @"CXCallEndedReasonDeclinedElsewhere": @(CXCallEndedReasonDeclinedElsewhere),
+  }), CXCallEndedReasonFailed, integerValue);
+@end
+
 @implementation RNCallKit
 {
     NSMutableDictionary *_settings;
@@ -35,6 +45,17 @@ static NSString *const RNCallKitDidPerformSetMutedCallAction = @"RNCallKitDidPer
 
 // should initialise in AppDelegate.m
 RCT_EXPORT_MODULE()
+
+- (NSDictionary *)constantsToExport
+{
+  return @{
+    @"CXCallEndedReasonFailed": @(CXCallEndedReasonFailed),
+    @"CXCallEndedReasonRemoteEnded": @(CXCallEndedReasonRemoteEnded),
+    @"CXCallEndedReasonUnanswered": @(CXCallEndedReasonUnanswered),
+    @"CXCallEndedReasonAnsweredElsewhere": @(CXCallEndedReasonAnsweredElsewhere),
+    @"CXCallEndedReasonDeclinedElsewhere": @(CXCallEndedReasonDeclinedElsewhere),
+  };
+};
 
 - (instancetype)init
 {
@@ -245,6 +266,12 @@ RCT_EXPORT_METHOD(reportConnectedOutgoingCallWithUUID:(NSString *)uuidString)
 {
     NSUUID *uuid = [[NSUUID alloc] initWithUUIDString:uuidString];
     [self.callKitProvider reportOutgoingCallWithUUID:uuid connectedAtDate:[NSDate date]];
+}
+
+RCT_EXPORT_METHOD(reportEndedCallWithUUID:(NSString *)uuidString reason:(CXCallEndedReason)reason)
+{
+    NSUUID *uuid = [[NSUUID alloc] initWithUUIDString:uuidString];
+    [self.callKitProvider reportCallWithUUID:uuid endedAtDate:[NSDate date] reason:CXCallEndedReasonFailed];
 }
 
 RCT_EXPORT_METHOD(setMutedCall:(NSString *)uuidString muted:(BOOL)muted resolver:(RCTPromiseResolveBlock) resolve rejecter: (RCTPromiseRejectBlock) reject)


### PR DESCRIPTION
Add support for [reportCallWithUUID:endedAtDate:reason:](https://developer.apple.com/documentation/callkit/cxcallendedreason?language=objc).

Should be used when a call is not ended by an explicit user action but e.g. by the remote caller. In this case, `CallKit.endCall` is inappropriate.