### PR TITLE
Proper casting to boolean

### DIFF
--- a/ios/RNCallKit/RNCallKit.m
+++ b/ios/RNCallKit/RNCallKit.m
@@ -390,11 +390,11 @@ RCT_EXPORT_METHOD(setMutedCall:(NSString *)uuidString muted:(BOOL)muted resolver
     providerConfiguration.supportedHandleTypes = [NSSet setWithObjects:[NSNumber numberWithInteger:CXHandleTypePhoneNumber], [NSNumber numberWithInteger:CXHandleTypeEmailAddress], [NSNumber numberWithInteger:CXHandleTypeGeneric], nil];
 
     if (_settings[@"supportsVideo"]) {
-        providerConfiguration.supportsVideo = _settings[@"supportsVideo"];
+        providerConfiguration.supportsVideo = ([_settings[@"supportsVideo"] boolValue]);
     }
 
     if (_settings[@"includesCallsInRecents"]) {
-        providerConfiguration.includesCallsInRecents = _settings[@"includesCallsInRecents"];
+        providerConfiguration.includesCallsInRecents = @([_settings[@"includesCallsInRecents"] boolValue]);
     }
 
     if (_settings[@"imageName"]) {


### PR DESCRIPTION
I finally figured out why there is a video button on the native UI call screen.

Apparently there are many different ways to represent a boolean in Objective-C. Apparently `_settings[@"supportsVideo"]` is an NSCFBoolean that need special casting to a “regular” bool. Or something 🤷‍♂️
